### PR TITLE
puller: adds code-clean up

### DIFF
--- a/puller/puller.go
+++ b/puller/puller.go
@@ -1,6 +1,7 @@
 package puller
 
 import (
+	"log"
 	"os"
 	"strings"
 
@@ -24,6 +25,18 @@ func (p *Puller) Pull(params *PullerParams) (*PullerResult, error) {
 	repos := []types.Repository{
 		params.Specification,
 		params.Implementation,
+	}
+
+	if _, err := os.Stat("./repos/"); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.Mkdir("repos", os.ModePerm); err != nil {
+				log.Println("1")
+				return nil, err
+			}
+		} else {
+			log.Println("2")
+			return nil, err
+		}
 	}
 
 	for _, r := range repos {

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -1,14 +1,16 @@
 package puller
 
 import (
-	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
 
 	"graphql-go/compatibility-standard-definitions/types"
 )
+
+const reposDirName = "repos"
 
 type Puller struct {
 }
@@ -27,20 +29,18 @@ func (p *Puller) Pull(params *PullerParams) (*PullerResult, error) {
 		params.Implementation,
 	}
 
-	if _, err := os.Stat("./repos/"); err != nil {
+	if _, err := os.Stat(reposDirName); err != nil {
 		if os.IsNotExist(err) {
-			if err := os.Mkdir("repos", os.ModePerm); err != nil {
-				log.Println("1")
+			if err := os.Mkdir(reposDirName, os.ModePerm); err != nil {
 				return nil, err
 			}
 		} else {
-			log.Println("2")
 			return nil, err
 		}
 	}
 
 	for _, r := range repos {
-		name := "./repos/" + r.Name
+		name := filepath.Join(reposDirName, r.Name)
 		if _, err := os.Stat(name); os.IsNotExist(err) {
 			if err := os.Mkdir(name, os.ModePerm); err != nil {
 				return nil, err


### PR DESCRIPTION
#### Details
- `puller`: parameterized repos dir name.
- `puller`: check if dir repos exists.

#### Test Plan
:heavy_check_mark: Tested that puller component works as expected:

```bash
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-standard-definitions$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/Oc
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag


(press q to quit)
Enumerating objects: 3863, done.
Counting objects: 100% (1494/1494), done.
Compressing objects: 100% (239/239), done.
Total 3863 (delta 1413), reused 1260 (delta 1254), pack-reused 2369 (from 2)
Enumerating objects: 5158, done.
Counting objects: 100% (81/81), done.
Compressing objects: 100% (52/52), done.
Total 5158 (delta 51), reused 29 (delta 29), pack-reused 5077 (from 4)
2025/03/06 12:28:01 &{Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1

```