### PR TITLE
extractor: adds working implementation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,9 @@
 package app
 
 import (
+	"log"
+
+	"graphql-go/compatibility-standard-definitions/extractor"
 	"graphql-go/compatibility-standard-definitions/puller"
 	"graphql-go/compatibility-standard-definitions/types"
 )
@@ -25,6 +28,14 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 	}); err != nil {
 		return nil, err
 	}
+
+	ex := extractor.Extractor{}
+	extractorResult, err := ex.Extract(&extractor.ExtractorParams{})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Println(extractorResult)
 
 	return &AppResult{}, nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -1,5 +1,10 @@
 package extractor
 
+import (
+	"log"
+	"os"
+)
+
 type ExtractorParams struct{}
 type ExtractorResult struct{}
 
@@ -7,5 +12,25 @@ type Extractor struct {
 }
 
 func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
+	typeSystemStr, err := e.readTypeSystem()
+	if err != nil {
+		return nil, err
+	}
+
+	log.Println(typeSystemStr)
+
 	return &ExtractorResult{}, nil
+}
+
+func (e *Extractor) readTypeSystem() (string, error) {
+	f, err := os.ReadFile("./repos/graphql-specification/spec/Section 3 -- Type System.md")
+	if err != nil {
+		return "", err
+	}
+
+	log.Println(string(f))
+
+	// return strings.Split(string(f), "\n"), nil
+
+	return "", nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -1,0 +1,11 @@
+package extractor
+
+type ExtractorParams struct{}
+type ExtractorResult struct{}
+
+type Extractor struct {
+}
+
+func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
+	return &ExtractorResult{}, nil
+}


### PR DESCRIPTION
#### Details
- `extractor`: adds extractor implementation.
- `app`: wires extractor component.
- `extractor`: adds extractor pkg.

#### Test Plan

:heavy_check_mark: Tested that the ... works as expected:


```bash
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)

...

Note: Details on implementing a GraphQL scalar specification can be found in the
[scalars.graphql.org implementation guide](https://scalars.graphql.org/implementation-guide).

In this example, a custom scalar type for `UUID` is defined with a URL pointing
to the relevant IETF specification.

...

2025/03/06 15:57:15 
2025/03/06 15:57:15 &{}
2025/03/06 15:57:15 &{Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1
}
2025/03/06 15:57:15 &{}
```
