### PR TITLE
introspection: Adding more introspection types.

### DIFF
--- a/types/introspection-directive.go
+++ b/types/introspection-directive.go
@@ -1,4 +1,42 @@
 package types
 
 type IntrospectionDirective struct {
+	name         string
+	description  string
+	isRepeatable bool
+	locations    DirectiveLocation
+	args         IntrospectionInputValue
+}
+
+type DirectiveLocation string
+
+const (
+	QUERY                  DirectiveLocation = "QUERY"
+	MUTATION                                 = "MUTATION"
+	SUBSCRIPTION                             = "SUBSCRIPTION"
+	FIELD                                    = "FIELD"
+	FRAGMENT_DEFINITION                      = "FRAGMENT_DEFINITION"
+	FRAGMENT_SPREAD                          = "FRAGMENT_SPREAD"
+	INLINE_FRAGMENT                          = "INLINE_FRAGMENT"
+	VARIABLE_DEFINITION                      = "VARIABLE_DEFINITION"
+	SCHEMA                                   = "SCHEMA"
+	SCALAR                                   = "SCALAR"
+	OBJECT                                   = "OBJECT"
+	FIELD_DEFINITION                         = "FIELD_DEFINITION"
+	ARGUMENT_DEFINITION                      = "ARGUMENT_DEFINITION"
+	INTERFACE                                = "INTERFACE"
+	UNION                                    = "UNION"
+	ENUM                                     = "ENUM"
+	ENUM_VALUE                               = "ENUM_VALUE"
+	INPUT_OBJECT                             = "INPUT_OBJECT"
+	INPUT_FIELD_DEFINITION                   = "INPUT_FIELD_DEFINITION"
+)
+
+type IntrospectionInputValue struct {
+	name        string
+	description string
+	// type IntrospectionInputTypeRef
+	defaultValue      string
+	isDeprecated      bool
+	deprecationReason string
 }

--- a/types/introspection-directive.go
+++ b/types/introspection-directive.go
@@ -1,11 +1,11 @@
 package types
 
 type IntrospectionDirective struct {
-	name         string
-	description  string
-	isRepeatable bool
-	locations    DirectiveLocation
-	args         IntrospectionInputValue
+	name         string                  `json:"name"`
+	description  string                  `json:"description"`
+	isRepeatable bool                    `json:"isRepeatable"`
+	locations    DirectiveLocation       `json:"locations"`
+	args         IntrospectionInputValue `json:"args"`
 }
 
 type DirectiveLocation string
@@ -33,10 +33,29 @@ const (
 )
 
 type IntrospectionInputValue struct {
-	name        string
-	description string
-	// type IntrospectionInputTypeRef
-	defaultValue      string
-	isDeprecated      bool
-	deprecationReason string
+	name              string                    `json:"name"`
+	description       string                    `json:"description"`
+	typeRef           IntrospectionInputTypeRef `json:"typeRef"`
+	defaultValue      string                    `json:"defaultValue"`
+	isDeprecated      bool                      `json:"isDeprecated"`
+	deprecationReason string                    `json:"deprecationReason"`
+}
+
+type IntrospectionInputType interface {
+}
+
+type IntrospectionInputTypeRef interface {
+}
+
+type IntrospectionNamedTypeRef interface {
+	IntrospectionInputType
+}
+
+type IntrospectionListTypeRef interface {
+	IntrospectionInputTypeRef
+}
+
+type IntrospectionNonNullTypeRef interface {
+	IntrospectionNamedTypeRef
+	IntrospectionListTypeRef
 }

--- a/types/introspection-type.go
+++ b/types/introspection-type.go
@@ -11,11 +11,12 @@ type IntrospectionScalarType struct {
 }
 
 type IntrospectionObjectType struct {
-	kind        string                     `json:"kind"`
-	name        string                     `json:"name"`
-	description string                     `json:"description"`
-	fields      IntrospectionField         `json:"fields"`
-	interfaces  IntrospectionInterfaceType `json:"interfaces"`
+	kind        string             `json:"kind"`
+	name        string             `json:"name"`
+	description string             `json:"description"`
+	fields      IntrospectionField `json:"fields"`
+	// TODO(@chris-ramon): Replace interface{} with other strategy.
+	interfaces interface{} `json:"interfaces"`
 }
 
 type IntrospectionInterfaceType struct {
@@ -23,8 +24,8 @@ type IntrospectionInterfaceType struct {
 	name        string             `json:"name"`
 	description string             `json:"description"`
 	fields      IntrospectionField `json:"fields"`
-	// TODO(@chris-ramon)
-	// interfaces    IntrospectionInterfaceType `json:"interfaces"`
+	// TODO(@chris-ramon): Replace interface{} with other strategy.
+	interfaces interface{} `json:"interfaces"`
 	// possibleTypes IntrospectionObjectType    `json:"possibleTypes"`
 }
 


### PR DESCRIPTION
#### Details
- `types`: adds directive types.
- `types`: adds IntrospectionInputTypeRef related types.
- `types`: consolidates introspection inner types.

#### Test Plan

:heavy_check_mark: Tested that the introspection works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/11 16:57:25 ## Type System Extensions
2025/03/11 16:57:25 ## Descriptions
...
```
