### PR TITLE
introspection: adds implementation

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -1,15 +1,19 @@
 package extractor
 
 import (
-	"log"
 	"os"
 	"strings"
 
 	"go/doc/comment"
+	"graphql-go/compatibility-standard-definitions/types"
 )
 
 type ExtractorParams struct{}
-type ExtractorResult struct{}
+
+type ExtractorResult struct {
+	SpecificationIntrospection  types.SpecificationIntrospection
+	ImplementationIntrospection types.ImplementationIntrospection
+}
 
 type Extractor struct {
 }
@@ -29,14 +33,17 @@ func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
 				switch val := t.(type) {
 				case comment.Plain:
 					if strings.HasPrefix(string(val), "##") {
-						log.Println(string(val))
+						// log.Println(string(val))
 					}
 				}
 			}
 		}
 	}
 
-	return &ExtractorResult{}, nil
+	return &ExtractorResult{
+		SpecificationIntrospection:  types.SpecificationIntrospection{},
+		ImplementationIntrospection: types.ImplementationIntrospection{},
+	}, nil
 }
 
 func (e *Extractor) readTypeSystem() ([]byte, error) {

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -8,16 +8,21 @@ import (
 	"graphql-go/compatibility-standard-definitions/types"
 )
 
-type ExtractorParams struct{}
+// Extractor represents the component that handles the extraction of standard definitions.
+type Extractor struct {
+}
 
+// ExtractorParams represents the parameters of the extract method.
+type ExtractorParams struct {
+}
+
+// ExtractorResult represents the result of the extract method.
 type ExtractorResult struct {
 	SpecificationIntrospection  types.SpecificationIntrospection
 	ImplementationIntrospection types.ImplementationIntrospection
 }
 
-type Extractor struct {
-}
-
+// Extract extracts and return the introspection result from the specification and a given implementation.
 func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
 	rawMarkdown, err := e.readTypeSystem()
 	if err != nil {
@@ -46,6 +51,7 @@ func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
 	}, nil
 }
 
+// readTypeSystem reads and return the type system of the graphql specification.
 func (e *Extractor) readTypeSystem() ([]byte, error) {
 	f, err := os.ReadFile("./repos/graphql-specification/spec/Section 3 -- Type System.md")
 	if err != nil {

--- a/types/introspection-query.go
+++ b/types/introspection-query.go
@@ -1,5 +1,5 @@
 package types
 
-type IntrospectionQuery struct {
+type IntrospectionQueryResult struct {
 	__schema IntrospectionSchema `json:"__schema"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -37,3 +37,11 @@ func (i *Implementation) MapKey(prefix string) string {
 type Specification struct {
 	Repo Repository
 }
+
+// SpecificationIntrospection represents the introspection result of the graphql specification.
+type SpecificationIntrospection struct {
+}
+
+// ImplementationIntrospection represents the introspection result of a graphql implementation.
+type ImplementationIntrospection struct {
+}

--- a/types/types.go
+++ b/types/types.go
@@ -40,8 +40,12 @@ type Specification struct {
 
 // SpecificationIntrospection represents the introspection result of the graphql specification.
 type SpecificationIntrospection struct {
+	// QueryResult contains the result of the introspection query.
+	QueryResult IntrospectionQueryResult
 }
 
 // ImplementationIntrospection represents the introspection result of a graphql implementation.
 type ImplementationIntrospection struct {
+	// QueryResult contains the result of the introspection query.
+	QueryResult IntrospectionQueryResult
 }


### PR DESCRIPTION
#### Details
- `extractor`: adds code comments.
- `types`: syncs introspection structs.
- `types`: adds introspection types fields.
- `extractor`: wires introspection related structs.
- `types`: adds introspection related fields.

#### Test Plan

:heavy_check_mark:  Tested that the introspection implementation works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
```
