### PR TITLE
extractor-&-validator: adds validator implementation and validator wiring.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,12 +4,14 @@ import (
 	"graphql-go/compatibility-standard-definitions/extractor"
 	"graphql-go/compatibility-standard-definitions/puller"
 	"graphql-go/compatibility-standard-definitions/types"
+	"graphql-go/compatibility-standard-definitions/validator"
 )
 
 type App struct {
 }
 
 type AppResult struct {
+	Message string
 }
 
 type AppParams struct {
@@ -28,9 +30,21 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 	}
 
 	ex := extractor.Extractor{}
-	if _, err := ex.Extract(&extractor.ExtractorParams{}); err != nil {
+	extractResult, err := ex.Extract(&extractor.ExtractorParams{})
+	if err != nil {
 		return nil, err
 	}
 
-	return &AppResult{}, nil
+	val := validator.Validator{}
+	validateResult, err := val.Validate(&validator.ValidateParams{
+		Specification:  extractResult.SpecificationIntrospection,
+		Implementation: extractResult.ImplementationIntrospection,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AppResult{
+		Message: validateResult.Result.String(),
+	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -28,10 +28,13 @@ func main() {
 	}
 
 	app := mainApp.App{}
-	if _, err := app.Run(mainApp.AppParams{
+	appResult, err := app.Run(mainApp.AppParams{
 		Specification:  implementation.GraphqlSpecification.Repo,
 		Implementation: implementation.GraphqlGoImplementation.Repo,
-	}); err != nil {
+	})
+	if err != nil {
 		log.Fatal(err)
 	}
+
+	log.Println(appResult.Message)
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -13,11 +13,8 @@ func (r Result) String() string {
 	switch r {
 	case Success:
 		return "SUCCESS"
-	case Failure:
-		return "FAILURE"
 	default:
-		return ""
-
+		return "FAILURE"
 	}
 
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -2,6 +2,26 @@ package validator
 
 import "graphql-go/compatibility-standard-definitions/types"
 
+type Result bool
+
+const (
+	Success Result = true
+	Failure Result = false
+)
+
+func (r Result) String() string {
+	switch r {
+	case Success:
+		return "SUCCESS"
+	case Failure:
+		return "FAILURE"
+	default:
+		return ""
+
+	}
+
+}
+
 // Validator represents the component that validates standard definitions.
 type Validator struct {
 }
@@ -14,9 +34,10 @@ type ValidateParams struct {
 
 // ValidateResult represents the result of the validate method.
 type ValidateResult struct {
+	Result Result
 }
 
 // Validates validates given graphql introspection query results.
 func (v *Validator) Validate(params *ValidateParams) (*ValidateResult, error) {
-	return nil, nil
+	return &ValidateResult{}, nil
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,0 +1,18 @@
+package validator
+
+// Validator represents the component that validates standard definitions.
+type Validator struct {
+}
+
+// ValidatorParams represents the parameters for the validate method.
+type ValidatorParams struct {
+}
+
+// ValidatorResult represents the result of the validate method.
+type ValidatorResult struct {
+}
+
+// Validates validates given graphql introspection query results.
+func (v *Validator) Validate(params *ValidatorParams) (*ValidatorResult, error) {
+	return nil, nil
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,18 +1,22 @@
 package validator
 
+import "graphql-go/compatibility-standard-definitions/types"
+
 // Validator represents the component that validates standard definitions.
 type Validator struct {
 }
 
-// ValidatorParams represents the parameters for the validate method.
-type ValidatorParams struct {
+// ValidateParams represents the parameters for the validate method.
+type ValidateParams struct {
+	Specification  types.SpecificationIntrospection
+	Implementation types.ImplementationIntrospection
 }
 
-// ValidatorResult represents the result of the validate method.
-type ValidatorResult struct {
+// ValidateResult represents the result of the validate method.
+type ValidateResult struct {
 }
 
 // Validates validates given graphql introspection query results.
-func (v *Validator) Validate(params *ValidatorParams) (*ValidatorResult, error) {
+func (v *Validator) Validate(params *ValidateParams) (*ValidateResult, error) {
 	return nil, nil
 }


### PR DESCRIPTION
#### Details
- `main`: wires app result.
- `validator`: sync Result.String method.
- `app`: wires Validator component.
- `validator`: adds ValidateResult.Result field.
- `validator`: syncs code comments.

#### Test Plan

[ ] Tested that the extractor and validator components works as expected:

to-be-added.
