### PR TITLE
extractor-validator-improvements

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -11,7 +11,8 @@ type App struct {
 }
 
 type AppResult struct {
-	Message string
+	Status  string
+	Details string
 }
 
 type AppParams struct {
@@ -45,6 +46,7 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 	}
 
 	return &AppResult{
-		Message: validateResult.Result.String(),
+		Status:  validateResult.Result.String(),
+		Details: validateResult.Difference,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -37,5 +37,8 @@ func main() {
 	}
 
 	log.Println(appResult.Status)
-	log.Println(appResult.Details)
+
+	if appResult.Details != "" {
+		log.Println(appResult.Details)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -36,5 +36,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Println(appResult.Message)
+	log.Println(appResult.Status)
+	log.Println(appResult.Details)
 }

--- a/types/introspection-directive.go
+++ b/types/introspection-directive.go
@@ -1,11 +1,11 @@
 package types
 
 type IntrospectionDirective struct {
-	name         string                  `json:"name"`
-	description  string                  `json:"description"`
-	isRepeatable bool                    `json:"isRepeatable"`
-	locations    DirectiveLocation       `json:"locations"`
-	args         IntrospectionInputValue `json:"args"`
+	Name         string                  `json:"name"`
+	Description  string                  `json:"description"`
+	IsRepeatable bool                    `json:"isRepeatable"`
+	Locations    DirectiveLocation       `json:"locations"`
+	Args         IntrospectionInputValue `json:"args"`
 }
 
 type DirectiveLocation string
@@ -33,12 +33,12 @@ const (
 )
 
 type IntrospectionInputValue struct {
-	name              string                    `json:"name"`
-	description       string                    `json:"description"`
-	typeRef           IntrospectionInputTypeRef `json:"typeRef"`
-	defaultValue      string                    `json:"defaultValue"`
-	isDeprecated      bool                      `json:"isDeprecated"`
-	deprecationReason string                    `json:"deprecationReason"`
+	Name              string                    `json:"name"`
+	Description       string                    `json:"description"`
+	TypeRef           IntrospectionInputTypeRef `json:"typeRef"`
+	DefaultValue      string                    `json:"defaultValue"`
+	IsDeprecated      bool                      `json:"isDeprecated"`
+	DeprecationReason string                    `json:"deprecationReason"`
 }
 
 type IntrospectionInputType interface {

--- a/types/introspection-query.go
+++ b/types/introspection-query.go
@@ -1,5 +1,5 @@
 package types
 
 type IntrospectionQueryResult struct {
-	Schema IntrospectionSchema `json:"schema"`
+	Schema IntrospectionSchema `json:"__schema"`
 }

--- a/types/introspection-schema.go
+++ b/types/introspection-schema.go
@@ -1,10 +1,10 @@
 package types
 
 type IntrospectionSchema struct {
-	description      string                  `json:"description"`
-	queryType        IntrospectionObjectType `json:"queryType"`
-	mutationType     IntrospectionObjectType `json:"mutationType"`
-	subscriptionType IntrospectionObjectType `json:"subscriptionType"`
-	types            IntrospectionType       `json:"types"`
-	directives       IntrospectionDirective  `json:"directives"`
+	Description      string                  `json:"description"`
+	QueryType        IntrospectionObjectType `json:"queryType"`
+	MutationType     IntrospectionObjectType `json:"mutationType"`
+	SubscriptionType IntrospectionObjectType `json:"subscriptionType"`
+	Types            IntrospectionType       `json:"types"`
+	Directives       IntrospectionDirective  `json:"directives"`
 }

--- a/types/introspection-type.go
+++ b/types/introspection-type.go
@@ -11,44 +11,44 @@ type IntrospectionScalarType struct {
 }
 
 type IntrospectionObjectType struct {
-	kind        string             `json:"kind"`
-	name        string             `json:"name"`
-	description string             `json:"description"`
-	fields      IntrospectionField `json:"fields"`
+	Kind        string             `json:"kind"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Fields      IntrospectionField `json:"fields"`
 	// TODO(@chris-ramon): Replace interface{} with other strategy.
-	interfaces interface{} `json:"interfaces"`
+	Interfaces interface{} `json:"interfaces"`
 }
 
 type IntrospectionInterfaceType struct {
-	kind        string             `json:"kind"`
-	name        string             `json:"name"`
-	description string             `json:"description"`
-	fields      IntrospectionField `json:"fields"`
+	Kind        string             `json:"kind"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Fields      IntrospectionField `json:"fields"`
 	// TODO(@chris-ramon): Replace interface{} with other strategy.
-	interfaces interface{} `json:"interfaces"`
+	Interfaces interface{} `json:"interfaces"`
 	// possibleTypes IntrospectionObjectType    `json:"possibleTypes"`
 }
 
 type IntrospectionUnionType struct {
-	kind          string                  `json:"kind"`
-	name          string                  `json:"name"`
-	description   string                  `json:"description"`
-	possibleTypes IntrospectionObjectType `json:"possibleTypes"`
+	Kind          string                  `json:"kind"`
+	Name          string                  `json:"name"`
+	Description   string                  `json:"description"`
+	PossibleTypes IntrospectionObjectType `json:"possibleTypes"`
 }
 
 type IntrospectionEnumType struct {
-	kind        string `json:"kind"`
-	name        string `json:"name"`
-	description string `json:"description"`
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 	// TODO(@chris-ramon)
 	// enumValues  IntrospectionEnumValue `json:"enumValues"`
 }
 
 type IntrospectionInputObjectType struct {
-	kind        string `json:"kind"`
-	name        string `json:"name"`
-	description string `json:"description"`
+	Kind        string `json:"kind"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
 	// TODO(@chris-ramon)
 	// inputFields IntrospectionInputValue `json:"inputFields"`
-	isOneOf bool `json:"isOneOf"`
+	IsOneOf bool `json:"isOneOf"`
 }


### PR DESCRIPTION
#### Details
- `types`: capitalizes struct fields.
- `types`: capitalizes first letter.
- `main`: adds app result details empty check.
- `main`: wires app result fields.
- `app`: consolidates AppResult fields.
- `types`: consolidates IntrospectionQueryResult.Schema json field name.

#### Test Plan

:heavy_check_mark: Tested that the extractor and validator works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/14 13:57:19 SUCCESS
```

