### PR TITLE
extractor & validator: adds loading spec introspection result from file.

### DIFF
--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -47,11 +47,16 @@ func (e *Extractor) readTypeSystem() ([]byte, error) {
 
 // extractSpec extracts and returns the introspection result of the graphql specification.
 func (e *Extractor) extractSpec() (types.SpecificationIntrospection, error) {
-	if _, err := parseSpec(); err != nil {
-		return nil, err
+	if _, err := e.parseSpec(); err != nil {
+		return types.SpecificationIntrospection{}, nil
 	}
 
-	return types.SpecificationIntrospection{}, nil
+	spec, err := e.loadSpec()
+	if err != nil {
+		return types.SpecificationIntrospection{}, nil
+	}
+
+	return spec, nil
 }
 
 // parseSpec parses and returns the introspection result of the graphql specification from the specification github repository.
@@ -76,4 +81,11 @@ func (e *Extractor) parseSpec() (types.SpecificationIntrospection, error) {
 			}
 		}
 	}
+
+	return types.SpecificationIntrospection{}, err
+}
+
+// loadSpec loads and returns the introspection result of the graphql javascript implementation.
+func (e *Extractor) loadSpec() (types.SpecificationIntrospection, error) {
+	return types.SpecificationIntrospection{}, nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -24,7 +24,6 @@ type ExtractorResult struct {
 
 // Extract extracts and return the introspection result from the specification and a given implementation.
 func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
-
 	specificationIntrospection, err := e.extractSpec()
 	if err != nil {
 		return nil, err
@@ -48,6 +47,15 @@ func (e *Extractor) readTypeSystem() ([]byte, error) {
 
 // extractSpec extracts and returns the introspection result of the graphql specification.
 func (e *Extractor) extractSpec() (types.SpecificationIntrospection, error) {
+	if _, err := parseSpec(); err != nil {
+		return nil, err
+	}
+
+	return types.SpecificationIntrospection{}, nil
+}
+
+// parseSpec parses and returns the introspection result of the graphql specification from the specification github repository.
+func (e *Extractor) parseSpec() (types.SpecificationIntrospection, error) {
 	rawMarkdown, err := e.readTypeSystem()
 	if err != nil {
 		return types.SpecificationIntrospection{}, err
@@ -68,6 +76,4 @@ func (e *Extractor) extractSpec() (types.SpecificationIntrospection, error) {
 			}
 		}
 	}
-
-	return types.SpecificationIntrospection{}, nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -46,6 +46,7 @@ func (e *Extractor) readTypeSystem() ([]byte, error) {
 	return f, nil
 }
 
+// extractSpec extracts and returns the introspection result of the graphql specification.
 func (e *Extractor) extractSpec() (types.SpecificationIntrospection, error) {
 	rawMarkdown, err := e.readTypeSystem()
 	if err != nil {

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -24,9 +24,32 @@ type ExtractorResult struct {
 
 // Extract extracts and return the introspection result from the specification and a given implementation.
 func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
-	rawMarkdown, err := e.readTypeSystem()
+
+	specificationIntrospection, err := e.extractSpec()
 	if err != nil {
 		return nil, err
+	}
+
+	return &ExtractorResult{
+		SpecificationIntrospection:  specificationIntrospection,
+		ImplementationIntrospection: types.ImplementationIntrospection{},
+	}, nil
+}
+
+// readTypeSystem reads and return the type system of the graphql specification.
+func (e *Extractor) readTypeSystem() ([]byte, error) {
+	f, err := os.ReadFile("./repos/graphql-specification/spec/Section 3 -- Type System.md")
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return f, nil
+}
+
+func (e *Extractor) extractSpec() (types.SpecificationIntrospection, error) {
+	rawMarkdown, err := e.readTypeSystem()
+	if err != nil {
+		return types.SpecificationIntrospection{}, err
 	}
 
 	parser := comment.Parser{}
@@ -45,18 +68,5 @@ func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
 		}
 	}
 
-	return &ExtractorResult{
-		SpecificationIntrospection:  types.SpecificationIntrospection{},
-		ImplementationIntrospection: types.ImplementationIntrospection{},
-	}, nil
-}
-
-// readTypeSystem reads and return the type system of the graphql specification.
-func (e *Extractor) readTypeSystem() ([]byte, error) {
-	f, err := os.ReadFile("./repos/graphql-specification/spec/Section 3 -- Type System.md")
-	if err != nil {
-		return []byte{}, err
-	}
-
-	return f, nil
+	return types.SpecificationIntrospection{}, nil
 }

--- a/types/introspection-directive.go
+++ b/types/introspection-directive.go
@@ -1,11 +1,11 @@
 package types
 
 type IntrospectionDirective struct {
-	Name         string                  `json:"name"`
-	Description  string                  `json:"description"`
-	IsRepeatable bool                    `json:"isRepeatable"`
-	Locations    DirectiveLocation       `json:"locations"`
-	Args         IntrospectionInputValue `json:"args"`
+	Name         string                    `json:"name"`
+	Description  string                    `json:"description"`
+	IsRepeatable bool                      `json:"isRepeatable"`
+	Locations    []DirectiveLocation       `json:"locations"`
+	Args         []IntrospectionInputValue `json:"args"`
 }
 
 type DirectiveLocation string

--- a/types/introspection-schema.go
+++ b/types/introspection-schema.go
@@ -1,10 +1,10 @@
 package types
 
 type IntrospectionSchema struct {
-	Description      string                  `json:"description"`
-	QueryType        IntrospectionObjectType `json:"queryType"`
-	MutationType     IntrospectionObjectType `json:"mutationType"`
-	SubscriptionType IntrospectionObjectType `json:"subscriptionType"`
-	Types            IntrospectionType       `json:"types"`
-	Directives       IntrospectionDirective  `json:"directives"`
+	Description      string                   `json:"description"`
+	QueryType        IntrospectionObjectType  `json:"queryType"`
+	MutationType     IntrospectionObjectType  `json:"mutationType"`
+	SubscriptionType IntrospectionObjectType  `json:"subscriptionType"`
+	Types            IntrospectionType        `json:"types"`
+	Directives       []IntrospectionDirective `json:"directives"`
 }


### PR DESCRIPTION
#### Details
- `extractor`: adds load spec functionality from file.
- `types`: syncs IntrospectionSchema Directives field.
- `types`: syncs IntrospectionDirective fields.
- `extractor`: adds Extractor.loadSpec method.
- `extractor`: consolidates inner spec loading.
- `extractor`: adds extractSpec comments.
- `extractor`: isolates spec introspection result.

#### Test Plan

:heavy_check_mark: Tested that the extractor and validator works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/14 16:54:14 FAILURE
2025/03/14 16:54:14   types.IntrospectionQueryResult{
  	Schema: types.IntrospectionSchema{
  		Description: "",
  		QueryType: types.IntrospectionObjectType{
- 			Kind:        "OBJECT",
+ 			Kind:        "",
...
- 		},
+ 		Directives: nil,
  	},
  }
```
