### PR TITLE
extractor & executor: adds executor component and wiring.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"graphql-go/compatibility-standard-definitions/executor"
 	"graphql-go/compatibility-standard-definitions/extractor"
 	"graphql-go/compatibility-standard-definitions/puller"
 	"graphql-go/compatibility-standard-definitions/types"
@@ -30,7 +31,9 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 		return nil, err
 	}
 
-	ex := extractor.New()
+	executor := executor.New()
+
+	ex := extractor.New(executor)
 	extractResult, err := ex.Extract(&extractor.ExtractorParams{})
 	if err != nil {
 		return nil, err

--- a/app/app.go
+++ b/app/app.go
@@ -34,7 +34,10 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 	executor := executor.New()
 
 	ex := extractor.New(executor)
-	extractResult, err := ex.Extract(&extractor.ExtractorParams{})
+	extractResult, err := ex.Extract(&extractor.ExtractorParams{
+		Implementation: params.Implementation,
+		Specification:  params.Specification,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -17,16 +17,16 @@ type AppResult struct {
 }
 
 type AppParams struct {
-	Specification  types.Repository
-	Implementation types.Repository
+	Specification  types.Specification
+	Implementation types.Implementation
 }
 
 func (app *App) Run(params AppParams) (*AppResult, error) {
 	p := puller.Puller{}
 
 	if _, err := p.Pull(&puller.PullerParams{
-		Specification:  params.Specification,
-		Implementation: params.Implementation,
+		Specification:  params.Specification.Repo,
+		Implementation: params.Implementation.Repo,
 	}); err != nil {
 		return nil, err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -30,7 +30,7 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 		return nil, err
 	}
 
-	ex := extractor.Extractor{}
+	ex := extractor.New()
 	extractResult, err := ex.Extract(&extractor.ExtractorParams{})
 	if err != nil {
 		return nil, err

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-GITHUB_AUTH_TOKEN=$GITHUB_AUTH_TOKEN go run main.go
+GITHUB_AUTH_TOKEN=$GITHUB_AUTH_TOKEN DEBUG=$DEBUG go run main.go

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"os"
+)
+
+// Config represents a set of configuration values.
+type Config struct {
+	IsDebug bool
+}
+
+// New returns a pointer to a Config struct.
+func New() *Config {
+	debug := os.Getenv("DEBUG")
+	isDebug := false
+
+	if debug == "true" {
+		isDebug = true
+	}
+
+	return &Config{
+		IsDebug: isDebug,
+	}
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2,11 +2,11 @@ package executor
 
 import (
 	"graphql-go/compatibility-standard-definitions/types"
-	"log"
 )
 
 // Executor handles the resolution of a graphql introspection query.
 type Executor struct {
+	goExecutor Go
 }
 
 // New returns a pointer to the Executor struct.
@@ -26,9 +26,15 @@ type ExecuteParams struct {
 
 // Execute executes and returns the resolution of a graphql introspection query.
 func (e *Executor) Execute(params ExecuteParams) (*ExecuteResult, error) {
-	log.Println(params.Implementation.Repo.Dir)
-	log.Println(params.Implementation.Introspection.Query)
+	runParams := &RunParams{
+		Query: params.Implementation.Introspection.Query,
+	}
+	result, err := e.goExecutor.Run(runParams)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ExecuteResult{
-		Result: "",
+		Result: result.Result,
 	}, nil
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,0 +1,18 @@
+package executor
+
+// Executor handles the resolution of a graphql introspection query.
+type Executor struct {
+}
+
+// ExecuteResult is the result of the execute method.
+type ExecuteResult struct {
+}
+
+// ExecuteParams is the params of the execute method.
+type ExecuteParams struct {
+}
+
+// Execute executes and returns the resolution of a graphql introspection query.
+func (e *Executor) Execute() (*ExecuteResult, error) {
+  return nil, nil
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,18 +1,34 @@
 package executor
 
+import (
+	"graphql-go/compatibility-standard-definitions/types"
+	"log"
+)
+
 // Executor handles the resolution of a graphql introspection query.
 type Executor struct {
 }
 
+// New returns a pointer to the Executor struct.
+func New() *Executor {
+	return &Executor{}
+}
+
 // ExecuteResult is the result of the execute method.
 type ExecuteResult struct {
+	Result string
 }
 
 // ExecuteParams is the params of the execute method.
 type ExecuteParams struct {
+	Implementation types.Implementation
 }
 
 // Execute executes and returns the resolution of a graphql introspection query.
-func (e *Executor) Execute() (*ExecuteResult, error) {
-  return nil, nil
+func (e *Executor) Execute(params ExecuteParams) (*ExecuteResult, error) {
+	log.Println(params.Implementation.Repo.Dir)
+	log.Println(params.Implementation.Introspection.Query)
+	return &ExecuteResult{
+		Result: "",
+	}, nil
 }

--- a/executor/go.go
+++ b/executor/go.go
@@ -1,5 +1,28 @@
 package executor
 
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/graphql-go/graphql"
+)
+
+var RootQuery = graphql.ObjectConfig{
+	Name: "RootQuery",
+	Fields: graphql.Fields{
+		"echo": &graphql.Field{
+			Type: graphql.String,
+			Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+				return "ok", nil
+			},
+		},
+	},
+}
+
+var SchemaConfig = graphql.SchemaConfig{
+	Query: graphql.NewObject(RootQuery),
+}
+
 // Go handles the go execution of a introspection query.
 type Go struct {
 }
@@ -16,5 +39,26 @@ type RunResult struct {
 
 // Run runs and returns a given introspection query.
 func (g *Go) Run(params *RunParams) (*RunResult, error) {
-	return &RunResult{}, nil
+	schema, err := graphql.NewSchema(SchemaConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	gqlParams := graphql.Params{
+		Schema:        schema,
+		RequestString: params.Query,
+	}
+	doResult := graphql.Do(gqlParams)
+	if doResult.Errors != nil {
+		return nil, fmt.Errorf("%+v", doResult.Errors)
+	}
+
+	result, err := json.Marshal(doResult)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunResult{
+		Result: string(result),
+	}, nil
 }

--- a/executor/go.go
+++ b/executor/go.go
@@ -1,0 +1,20 @@
+package executor
+
+// Go handles the go execution of a introspection query.
+type Go struct {
+}
+
+// RunParams represents the params of the run method.
+type RunParams struct {
+	Query string
+}
+
+// RunResult represents the result of the run method.
+type RunResult struct {
+	Result string
+}
+
+// Run runs and returns a given introspection query.
+func (g *Go) Run(params *RunParams) (*RunResult, error) {
+	return &RunResult{}, nil
+}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -19,11 +19,14 @@ const introspectionQueryFilePath string = "./graphql-js-introspection/query.grap
 
 // Extractor represents the component that handles the extraction of standard definitions.
 type Extractor struct {
+	executor executor.Executor
 }
 
 // New returns a pointer to a Extractor struct.
-func New() *Extractor {
-	return &Extractor{}
+func New(executor executor.Executor) *Extractor {
+	return &Extractor{
+		executor: executor,
+	}
 }
 
 // ExtractorParams represents the parameters of the extract method.

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -32,6 +32,8 @@ func New(executor *executor.Executor) *Extractor {
 
 // ExtractorParams represents the parameters of the extract method.
 type ExtractorParams struct {
+	Specification  types.Implementation
+	Implementation types.Implementation
 }
 
 // ExtractorResult represents the result of the extract method.

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -3,7 +3,6 @@ package extractor
 import (
 	"encoding/json"
 	"io"
-	"log"
 	"os"
 	"strings"
 
@@ -92,17 +91,15 @@ func (e *Extractor) extractImplementation() (*types.ImplementationIntrospection,
 		return nil, err
 	}
 
-	result, err := e.executor.Execute(executor.ExecuteParams{
+	if _, err := e.executor.Execute(executor.ExecuteParams{
 		Implementation: types.Implementation{
 			Introspection: types.Introspection{
 				Query: string(introspectionQuery),
 			},
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, err
 	}
-	log.Println(result)
 
 	return &types.ImplementationIntrospection{}, nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"go/doc/comment"
+	"graphql-go/compatibility-standard-definitions/executor"
 	"graphql-go/compatibility-standard-definitions/types"
 )
 
@@ -19,11 +20,11 @@ const introspectionQueryFilePath string = "./graphql-js-introspection/query.grap
 
 // Extractor represents the component that handles the extraction of standard definitions.
 type Extractor struct {
-	executor executor.Executor
+	executor *executor.Executor
 }
 
 // New returns a pointer to a Extractor struct.
-func New(executor executor.Executor) *Extractor {
+func New(executor *executor.Executor) *Extractor {
 	return &Extractor{
 		executor: executor,
 	}
@@ -91,7 +92,17 @@ func (e *Extractor) extractImplementation() (*types.ImplementationIntrospection,
 		return nil, err
 	}
 
-	log.Println(string(introspectionQuery))
+	result, err := e.executor.Execute(executor.ExecuteParams{
+		Implementation: types.Implementation{
+			Introspection: types.Introspection{
+				Query: string(introspectionQuery),
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	log.Println(result)
 
 	return &types.ImplementationIntrospection{}, nil
 }

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -19,6 +19,7 @@ const introspectionQueryFilePath string = "./graphql-js-introspection/query.grap
 
 // Extractor represents the component that handles the extraction of standard definitions.
 type Extractor struct {
+	// executor is the executor component that extractor delegates the execution of a graphql introspection query.
 	executor *executor.Executor
 }
 

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -32,8 +32,8 @@ func New(executor *executor.Executor) *Extractor {
 
 // ExtractorParams represents the parameters of the extract method.
 type ExtractorParams struct {
-	Specification  types.Implementation
 	Implementation types.Implementation
+	Specification  types.Specification
 }
 
 // ExtractorResult represents the result of the extract method.
@@ -52,7 +52,7 @@ func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
 		return nil, err
 	}
 
-	implementationIntrospection, err := e.extractImplementation()
+	implementationIntrospection, err := e.extractImplementation(params.Implementation)
 	if err != nil {
 		return nil, err
 	}
@@ -88,18 +88,18 @@ func (e *Extractor) extractSpec() (*types.SpecificationIntrospection, error) {
 }
 
 // extractImplementation extracts and returns the introspection result of a graphql implementation.
-func (e *Extractor) extractImplementation() (*types.ImplementationIntrospection, error) {
+func (e *Extractor) extractImplementation(implementation types.Implementation) (*types.ImplementationIntrospection, error) {
 	introspectionQuery, err := e.loadIntrospectionQuery()
 	if err != nil {
 		return nil, err
 	}
 
+	implementation.Introspection = types.Introspection{
+		Query: string(introspectionQuery),
+	}
+
 	if _, err := e.executor.Execute(executor.ExecuteParams{
-		Implementation: types.Implementation{
-			Introspection: types.Introspection{
-				Query: string(introspectionQuery),
-			},
-		},
+		Implementation: implementation,
 	}); err != nil {
 		return nil, err
 	}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -21,6 +21,11 @@ const introspectionQueryFilePath string = "./graphql-js-introspection/query.grap
 type Extractor struct {
 }
 
+// New returns a pointer to a Extractor struct.
+func New() *Extractor {
+	return &Extractor{}
+}
+
 // ExtractorParams represents the parameters of the extract method.
 type ExtractorParams struct {
 }

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/graphql-go/graphql v0.8.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8J
 github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/graphql-go/graphql v0.8.1 h1:p7/Ou/WpmulocJeEx7wjQy611rtXGQaAcXGqanuMMgc=
+github.com/graphql-go/graphql v0.8.1/go.mod h1:nKiHzRM0qopJEwCITUuIsxk9PlVlwIiiI8pnJEhordQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/main.go
+++ b/main.go
@@ -30,8 +30,8 @@ func main() {
 
 	app := mainApp.App{}
 	appResult, err := app.Run(mainApp.AppParams{
-		Specification:  implementation.GraphqlSpecification.Repo,
-		Implementation: implementation.GraphqlGoImplementation.Repo,
+		Specification:  implementation.GraphqlSpecification,
+		Implementation: implementation.GraphqlGoImplementation,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 
 	mainApp "graphql-go/compatibility-standard-definitions/app"
 	"graphql-go/compatibility-standard-definitions/cmd"
+	"graphql-go/compatibility-standard-definitions/config"
 	"graphql-go/compatibility-standard-definitions/implementation"
 )
 
@@ -36,9 +37,11 @@ func main() {
 		log.Fatal(err)
 	}
 
+	cfg := config.New()
+
 	log.Println(appResult.Status)
 
-	if appResult.Details != "" {
+	if appResult.Details != "" && cfg.IsDebug == false {
 		log.Println(appResult.Details)
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -23,9 +23,14 @@ func (r *Repository) String(prefix string) string {
 	return fmt.Sprintf(base, r.URL, r.ReferenceName)
 }
 
+type Introspection struct {
+	Query string
+}
+
 type Implementation struct {
 	Repo              Repository
 	Type              ImplementationType
+	Introspection     Introspection
 	TestNames         []string
 	TestNamesFilePath string
 }


### PR DESCRIPTION
#### Details
- `executor`: wiring graphql-go/graphql executor resolution.
- `{go.mod,go.sum}`: adds github.com/graphql-go/graphql dependency.
- `executor`: wiring go executor.
- `executor`: adds go executor component.
- `app`: wires extractor params.
- `extractor`: consolidates extract implementation method.
- `main`: syncs types.
- `app`: syncs AppParams fields.
- `extractor`: adds ExtractorParams fields.
- `extrator`: adding Extractor fields code comments.
- `extractor`: removes debug log and improves execute method call.
- `main`: wires Config component.
- `bin`: adds DEBUG param.
- `config`: adds Config struct.
- `executor`: initial implementation of execute method.
- `extractor`: wiring execute component to extractor component.
- `types`: adds Introspection struct.
- `{app,extractor}`: wiring executor to extractor component.
- `app`: wire extractor New method.
- `extractor`: adds New method.
- `executor`: adds initial structure of the executor component.

#### Test Plan

:heavy_check_mark:  Tested that the extractor and executor components works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/18 16:51:27 [Cannot query field "description" on type "__Schema". Did you mean "subscriptionType"? Cannot query field "isRepeatable" on type "__Directive". Unknown argument "includeDeprecated" on field "args" of type "__Directive". Cannot query field "specifiedByURL" on type "__Type". Cannot query field "isOneOf" on type "__Type". Unknown argument "includeDeprecated" on field "args" of type "__Field". Unknown argument "includeDeprecated" on field "inputFields" of type "__Type". Cannot query field "isDeprecated" on type "__InputValue". Cannot query field "deprecationReason" on type "__InputValue".]
exit status 1
```
