### PR TITLE
types: adds code comments.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -11,17 +11,17 @@ import (
 type App struct {
 }
 
-type AppResult struct {
+type RunResult struct {
 	Status  string
 	Details string
 }
 
-type AppParams struct {
+type RunParams struct {
 	Specification  types.Specification
 	Implementation types.Implementation
 }
 
-func (app *App) Run(params AppParams) (*AppResult, error) {
+func (app *App) Run(params RunParams) (*RunResult, error) {
 	p := puller.Puller{}
 
 	if _, err := p.Pull(&puller.PullerParams{
@@ -51,7 +51,7 @@ func (app *App) Run(params AppParams) (*AppResult, error) {
 		return nil, err
 	}
 
-	return &AppResult{
+	return &RunResult{
 		Status:  validateResult.Result.String(),
 		Details: validateResult.Difference,
 	}, nil

--- a/main.go
+++ b/main.go
@@ -9,11 +9,12 @@ import (
 	"graphql-go/compatibility-standard-definitions/implementation"
 )
 
-var choices = []string{}
+// implementationChoices is the list of graphql implementation choices.
+var implementationChoices = []string{}
 
 func init() {
 	for _, i := range implementation.Implementations {
-		choices = append(choices, i.Repo.String(implementation.ImplementationPrefix))
+		implementationChoices = append(implementationChoices, i.Repo.String(implementation.ImplementationPrefix))
 	}
 }
 
@@ -22,7 +23,7 @@ func main() {
 
 	cli := cmd.CLI{}
 	if _, err := cli.Run(&cmd.RunParams{
-		Choices: choices,
+		Choices: implementationChoices,
 		Header:  header,
 	}); err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	app := mainApp.App{}
-	appResult, err := app.Run(mainApp.AppParams{
+	runResult, err := app.Run(mainApp.RunParams{
 		Specification:  implementation.GraphqlSpecification,
 		Implementation: implementation.GraphqlGoImplementation,
 	})
@@ -40,9 +40,9 @@ func main() {
 
 	cfg := config.New()
 
-	log.Println(appResult.Status)
+	log.Println(runResult.Status)
 
-	if appResult.Details != "" && cfg.IsDebug == false {
-		log.Println(appResult.Details)
+	if runResult.Details != "" && cfg.IsDebug == false {
+		log.Println(runResult.Details)
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -40,7 +40,7 @@ func (r *Repository) String(prefix string) string {
 
 // Introspection represents a graphql introspection.
 type Introspection struct {
-  // Query is the introspection query.
+	// Query is the introspection query.
 	Query string
 }
 
@@ -57,6 +57,9 @@ type Implementation struct {
 
 	// TestNamesFilePath is the file path of the test names.
 	TestNamesFilePath string
+
+	// Introspection is the introspection of the implementation.
+	Introspection Introspection
 }
 
 // MapKey returns the map key of the implementation.

--- a/types/types.go
+++ b/types/types.go
@@ -1,3 +1,4 @@
+// package types defines the internal types.
 package types
 
 import "fmt"
@@ -31,27 +32,39 @@ type Repository struct {
 	Dir string
 }
 
+// String returns the string summary of the code repository.
 func (r *Repository) String(prefix string) string {
 	base := fmt.Sprintf("%s: %s\n", prefix, taggedRepoURL)
 	return fmt.Sprintf(base, r.URL, r.ReferenceName)
 }
 
+// Introspection represents a graphql introspection.
 type Introspection struct {
+  // Query is the introspection query.
 	Query string
 }
 
+// Implementation represents a graphql implementation.
 type Implementation struct {
-	Repo              Repository
-	Type              ImplementationType
-	Introspection     Introspection
-	TestNames         []string
+	// Repo is the code repository of the implementation.
+	Repo Repository
+
+	// Type is the implementation type.
+	Type ImplementationType
+
+	// TestNames is the list of test names of the implementation.
+	TestNames []string
+
+	// TestNamesFilePath is the file path of the test names.
 	TestNamesFilePath string
 }
 
+// MapKey returns the map key of the implementation.
 func (i *Implementation) MapKey(prefix string) string {
 	return i.Repo.String(prefix)
 }
 
+// Specification represents a graphql specification.
 type Specification struct {
 	Repo Repository
 }

--- a/types/types.go
+++ b/types/types.go
@@ -2,20 +2,33 @@ package types
 
 import "fmt"
 
+// taggedRepoURL is the repo url of a tag of releases.
 const taggedRepoURL string = "%s/releases/tag/%s"
 
+// ImplementationType is the type of implementations.
 type ImplementationType uint
 
 const (
+	// GoImplementationType is the type of a go implementation.
 	GoImplementationType = iota + 1
+
+	// RefImplementationType is the type of the graphql reference implementation.
 	RefImplementationType
 )
 
+// Repository represents the code repository of a graphql implementation.
 type Repository struct {
-	Name          string
-	URL           string
+	// Name is the code repository name.
+	Name string
+
+	// URL is the code repository URL.
+	URL string
+
+	// ReferenceName is the code repository reference name, eg. GitHub a tag.
 	ReferenceName string
-	Dir           string
+
+	// Dir is the code repository directory path.
+	Dir string
 }
 
 func (r *Repository) String(prefix string) string {


### PR DESCRIPTION
#### Details
- `types`: adds code comments.

#### Test Plan

:heavy_check_mark:  Tested that the cli works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/19 16:18:59 query IntrospectionQuery {
  __schema {
    description
    queryType {
...
- 			{
- 				Name:        "oneOf",
- 				Description: "Indicates exactly one field must be supplied and this field must"...,
- 				Locations:   []types.DirectiveLocation{"INPUT_OBJECT"},
- 				Args:        []types.IntrospectionInputValue{},
- 			},
- 		},
+ 		Directives: nil,
  	},
  }
```
