### PR TITLE
{implementation,main,mapper}: Code comments and implementation refactoring.

### DIFF
--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -56,15 +56,3 @@ var RefImplementation = GraphqlJSImplementation
 
 // Implementations is the default list of graphql implementations.
 var Implementations = []types.Implementation{GraphqlGoImplementation}
-
-// gqlGoImplURL is the default map-key of graphql-go implementation.
-var gqlGoImplURL = GraphqlGoImplementation.MapKey(ImplementationPrefix)
-
-// jsImplURL is the default map-key of the graphql-js implementation.
-var jsImplURL = GraphqlJSImplementation.MapKey(ImplementationPrefix)
-
-// ImplementationsMap is the default map of graphql implementations.
-var ImplementationsMap = map[string]types.Implementation{
-	gqlGoImplURL: GraphqlGoImplementation,
-	jsImplURL:    GraphqlJSImplementation,
-}

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -4,10 +4,16 @@ import (
 	"graphql-go/compatibility-standard-definitions/types"
 )
 
+// ImplementationPrefix is the default implementation prefix.
 const ImplementationPrefix = "Implementation"
+
+// RefImplementationPrefix is the reference implementation prefix.
 const RefImplementationPrefix = "Reference Implementation"
+
+// SpecificationPrefix is a implementation prefix.
 const SpecificationPrefix = "Specification"
 
+// GraphqlGoImplementation represents the graphql-go implementation.
 var GraphqlGoImplementation = types.Implementation{
 	Repo: types.Repository{
 		Name:          "graphql-go-graphql",
@@ -18,6 +24,7 @@ var GraphqlGoImplementation = types.Implementation{
 	Type: types.GoImplementationType,
 }
 
+// GraphqlJSImplementation represents the graphql-js implementation.
 var GraphqlJSImplementation = types.Implementation{
 	Repo: types.Repository{
 		Name:          "graphql-graphql-js",
@@ -29,6 +36,7 @@ var GraphqlJSImplementation = types.Implementation{
 	TestNamesFilePath: "./puller-js/unit-tests.txt",
 }
 
+// GraphqlSpecification represents the graphql specification.
 var GraphqlSpecification = types.Specification{
 	Repo: types.Repository{
 		Name:          "graphql-specification",
@@ -43,13 +51,19 @@ func GraphqlSpecificationWithPrefix() string {
 	return GraphqlSpecification.Repo.String(SpecificationPrefix)
 }
 
+// RefImplementation is the default reference implementation.
 var RefImplementation = GraphqlJSImplementation
 
+// Implementations is the default list of graphql implementations.
 var Implementations = []types.Implementation{GraphqlGoImplementation}
 
+// gqlGoImplURL is the default map-key of graphql-go implementation.
 var gqlGoImplURL = GraphqlGoImplementation.MapKey(ImplementationPrefix)
+
+// jsImplURL is the default map-key of the graphql-js implementation.
 var jsImplURL = GraphqlJSImplementation.MapKey(ImplementationPrefix)
 
+// ImplementationsMap is the default map of graphql implementations.
 var ImplementationsMap = map[string]types.Implementation{
 	gqlGoImplURL: GraphqlGoImplementation,
 	jsImplURL:    GraphqlJSImplementation,

--- a/implementation/implementation.go
+++ b/implementation/implementation.go
@@ -38,6 +38,11 @@ var GraphqlSpecification = types.Specification{
 	},
 }
 
+// GraphqlSpecificationWithPrefix returns the graphql specification repository link with a prefix.
+func GraphqlSpecificationWithPrefix() string {
+	return GraphqlSpecification.Repo.String(SpecificationPrefix)
+}
+
 var RefImplementation = GraphqlJSImplementation
 
 var Implementations = []types.Implementation{GraphqlGoImplementation}

--- a/main.go
+++ b/main.go
@@ -11,12 +11,10 @@ import (
 )
 
 func main() {
-	header := implementation.GraphqlSpecification.Repo.String(implementation.SpecificationPrefix)
-
 	cli := cmd.CLI{}
 	if _, err := cli.Run(&cmd.RunParams{
 		Choices: mapper.AvailableImplementations(),
-		Header:  header,
+		Header:  implementation.GraphqlSpecificationWithPrefix(),
 	}); err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -7,23 +7,15 @@ import (
 	"graphql-go/compatibility-standard-definitions/cmd"
 	"graphql-go/compatibility-standard-definitions/config"
 	"graphql-go/compatibility-standard-definitions/implementation"
+	"graphql-go/compatibility-standard-definitions/mapper"
 )
-
-// implementationChoices is the list of graphql implementation choices.
-var implementationChoices = []string{}
-
-func init() {
-	for _, i := range implementation.Implementations {
-		implementationChoices = append(implementationChoices, i.Repo.String(implementation.ImplementationPrefix))
-	}
-}
 
 func main() {
 	header := implementation.GraphqlSpecification.Repo.String(implementation.SpecificationPrefix)
 
 	cli := cmd.CLI{}
 	if _, err := cli.Run(&cmd.RunParams{
-		Choices: implementationChoices,
+		Choices: mapper.AvailableImplementations(),
 		Header:  header,
 	}); err != nil {
 		log.Fatal(err)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -1,0 +1,16 @@
+package mapper
+
+import (
+	"graphql-go/compatibility-standard-definitions/implementation"
+)
+
+// AvailableImplementations returns a list of available implementations.
+func AvailableImplementations() []string {
+	var implementations = []string{}
+
+	for _, i := range implementation.Implementations {
+		implementations = append(implementations, i.Repo.String(implementation.ImplementationPrefix))
+	}
+
+	return implementations
+}


### PR DESCRIPTION
#### Details
- `implementation`: removes unused code.
- `implementation`: adds code comments.
- `main`: wires `GraphqlSpecificationWithPrefix` function.
- `implementation`: adds `GraphqlSpecificationWithPrefix` function.
- `main`: consolidating available implementations.
- `mapper`: adds `AvailableImplementations` function.

#### Test Plan

:heavy_check_mark:  Tested that the cli works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/20 13:33:13 [Cannot query field "description" on type "__Schema". Did you mean "subscriptionType"? Cannot query field "isRepeatable" on type "__Directive". Unknown argument "includeDeprecated" on field "args" of type "__Directive". Cannot query field "specifiedByURL" on type "__Type". Cannot query field "isOneOf" on type "__Type". Unknown argument "includeDeprecated" on field "args" of type "__Field". Unknown argument "includeDeprecated" on field "inputFields" of type "__Type". Cannot query field "isDeprecated" on type "__InputValue". Cannot query field "deprecationReason" on type "__InputValue".]
exit status 1
```
