### PR TITLE
{app,puller,validator}: adds code comments.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -8,19 +8,26 @@ import (
 	"graphql-go/compatibility-standard-definitions/validator"
 )
 
+// App represents the high level entry point for the application.
 type App struct {
 }
 
+// RunResult represents the result of the run method.
 type RunResult struct {
 	Status  string
 	Details string
 }
 
+// RunParams represents the params of the run method.
 type RunParams struct {
-	Specification  types.Specification
+	// Specification is the graphql specification.
+	Specification types.Specification
+
+	// Implementation is the graphql implementation.
 	Implementation types.Implementation
 }
 
+// Run runs and returns the application.
 func (app *App) Run(params RunParams) (*RunResult, error) {
 	p := puller.Puller{}
 

--- a/app/app.go
+++ b/app/app.go
@@ -27,7 +27,7 @@ type RunParams struct {
 	Implementation types.Implementation
 }
 
-// Run runs and returns the application.
+// Run runs and returns the application result.
 func (app *App) Run(params RunParams) (*RunResult, error) {
 	p := puller.Puller{}
 

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -19,10 +19,10 @@ type Puller struct {
 
 // PullerParams represents the parameters of the pull method.
 type PullerParams struct {
-	// Specification is the repository of the graphql specification.
+	// Specification is the code repository of the graphql specification.
 	Specification types.Repository
 
-	// Implementation is the repository of the graphql implementation.
+	// Implementation is the code repository of the graphql implementation.
 	Implementation types.Repository
 }
 

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -10,19 +10,27 @@ import (
 	"graphql-go/compatibility-standard-definitions/types"
 )
 
+// reposDirName is the code repository root directory name.
 const reposDirName = "repos"
 
+// Puller represents the puller component.
 type Puller struct {
 }
 
-type PullerResult struct {
-}
-
+// PullerParams represents the parameters of the pull method.
 type PullerParams struct {
-	Specification  types.Repository
+	// Specification is the repository of the graphql specification.
+	Specification types.Repository
+
+	// Implementation is the repository of the graphql implementation.
 	Implementation types.Repository
 }
 
+// PullerResult represents the result of the pull method.
+type PullerResult struct {
+}
+
+// Pull pulls a set of code repositories and returns if it succeeded or not.
 func (p *Puller) Pull(params *PullerParams) (*PullerResult, error) {
 	repos := []types.Repository{
 		params.Specification,

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -6,13 +6,18 @@ import (
 	"graphql-go/compatibility-standard-definitions/types"
 )
 
+// Result represents a result type of the validator component.
 type Result bool
 
 const (
+	// Success represents a success result.
 	Success Result = true
+
+	// Failure represents a failure result.
 	Failure Result = false
 )
 
+// String returns the string representation of the result.
 func (r Result) String() string {
 	switch r {
 	case Success:


### PR DESCRIPTION
#### Details
- `app`: adds code comments.
- `puller`: adds code comments.
- `validator`: adds code comments.

#### Test Plan

:heavy_check_mark:  Tested that the cli app works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/20 16:00:33 [Cannot query field "description" on type "__Schema". Did you mean "subscriptionType"? Cannot query field "isRepeatable" on type "__Directive". Unknown argument "includeDeprecated" on field "args" of type "__Directive". Cannot query field "specifiedByURL" on type "__Type". Cannot query field "isOneOf" on type "__Type". Unknown argument "includeDeprecated" on field "args" of type "__Field". Unknown argument "includeDeprecated" on field "inputFields" of type "__Type". Cannot query field "isDeprecated" on type "__InputValue". Cannot query field "deprecationReason" on type "__InputValue".]
exit status 1
```
