### PR TITLE
golangci-lint: fixes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -32,7 +32,7 @@ type RunParams struct {
 func (app *App) Run(params RunParams) (*RunResult, error) {
 	p := puller.Puller{}
 
-	if _, err := p.Pull(&puller.PullerParams{
+	if _, err := p.Pull(&puller.PullParams{
 		Specification:  params.Specification.Repo,
 		Implementation: params.Implementation.Repo,
 	}); err != nil {
@@ -43,7 +43,7 @@ func (app *App) Run(params RunParams) (*RunResult, error) {
 
 	ex := extractor.New(executor)
 
-	extractResult, err := ex.Extract(&extractor.ExtractorParams{
+	extractResult, err := ex.Extract(&extractor.ExtractParams{
 		Implementation: params.Implementation,
 		Specification:  params.Specification,
 	})

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -124,8 +124,8 @@ func (e *Extractor) parseSpec() (types.SpecificationIntrospection, error) {
 		p, ok := d.(*comment.Paragraph)
 		if ok {
 			for _, t := range p.Text {
-				switch val := t.(type) {
-				case comment.Plain:
+				val, ok := t.(comment.Plain)
+				if ok {
 					if strings.HasPrefix(string(val), "##") {
 						// log.Println(string(val))
 					}

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -31,14 +31,14 @@ func New(executor *executor.Executor) *Extractor {
 	}
 }
 
-// ExtractorParams represents the parameters of the extract method.
-type ExtractorParams struct {
+// ExtractParams represents the parameters of the extract method.
+type ExtractParams struct {
 	Implementation types.Implementation
 	Specification  types.Specification
 }
 
-// ExtractorResult represents the result of the extract method.
-type ExtractorResult struct {
+// ExtractResult represents the result of the extract method.
+type ExtractResult struct {
 	// SpecificationIntrospection is the introspection types of the graphql specification.
 	SpecificationIntrospection *types.SpecificationIntrospection
 
@@ -47,7 +47,7 @@ type ExtractorResult struct {
 }
 
 // Extract extracts and return the introspection result from the specification and a given implementation.
-func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
+func (e *Extractor) Extract(params *ExtractParams) (*ExtractResult, error) {
 	specificationIntrospection, err := e.extractSpec()
 	if err != nil {
 		return nil, fmt.Errorf("failed extract specification: %w", err)
@@ -58,7 +58,7 @@ func (e *Extractor) Extract(params *ExtractorParams) (*ExtractorResult, error) {
 		return nil, fmt.Errorf("failed extract implementation: %w", err)
 	}
 
-	return &ExtractorResult{
+	return &ExtractResult{
 		SpecificationIntrospection:  specificationIntrospection,
 		ImplementationIntrospection: implementationIntrospection,
 	}, nil
@@ -119,6 +119,8 @@ func (e *Extractor) parseSpec() (types.SpecificationIntrospection, error) {
 
 	parser := comment.Parser{}
 
+	headingsLevel2 := []string{}
+
 	doc := parser.Parse(string(rawMarkdown))
 	for _, d := range doc.Content {
 		p, ok := d.(*comment.Paragraph)
@@ -127,7 +129,7 @@ func (e *Extractor) parseSpec() (types.SpecificationIntrospection, error) {
 				val, ok := t.(comment.Plain)
 				if ok {
 					if strings.HasPrefix(string(val), "##") {
-						// log.Println(string(val))
+						headingsLevel2 = append(headingsLevel2, string(val))
 					}
 				}
 			}

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -18,8 +18,8 @@ const reposDirName = "repos"
 type Puller struct {
 }
 
-// PullerParams represents the parameters of the pull method.
-type PullerParams struct {
+// PullParams represents the parameters of the pull method.
+type PullParams struct {
 	// Specification is the code repository of the graphql specification.
 	Specification types.Repository
 
@@ -27,12 +27,12 @@ type PullerParams struct {
 	Implementation types.Repository
 }
 
-// PullerResult represents the result of the pull method.
-type PullerResult struct {
+// PullResult represents the result of the pull method.
+type PullResult struct {
 }
 
 // Pull pulls a set of code repositories and returns if it succeeded or not.
-func (p *Puller) Pull(params *PullerParams) (*PullerResult, error) {
+func (p *Puller) Pull(params *PullParams) (*PullResult, error) {
 	repos := []types.Repository{
 		params.Specification,
 		params.Implementation,
@@ -69,5 +69,5 @@ func (p *Puller) Pull(params *PullerParams) (*PullerResult, error) {
 		}
 	}
 
-	return &PullerResult{}, nil
+	return &PullResult{}, nil
 }


### PR DESCRIPTION
#### Details
- `{app,puller}`: fixes for golangci-lint `revive` linter.
- `extractor`: fixes for golangci-lint `gocritic` linter.

#### Test Plan

:heavy_check_mark:  Tested that the cli app works as expected:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-standard-definitions$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/25 16:57:36 failed to extract: failed extract implementation: failed to execute: Cannot query field "deprecationReason" on type "__InputValue".: Cannot query field "isDeprecated" on type "__InputValue".: Unknown argument "includeDeprecated" on field "inputFields" of type "__Type".: Unknown argument "includeDeprecated" on field "args" of type "__Field".: Cannot query field "isOneOf" on type "__Type".: Cannot query field "specifiedByURL" on type "__Type".: Unknown argument "includeDeprecated" on field "args" of type "__Directive".: Cannot query field "isRepeatable" on type "__Directive".: Cannot query field "description" on type "__Schema". Did you mean "subscriptionType"?
exit status 1
```
