### PR TITLE
golangci-lint: linting fixes and config updates.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,17 +3,18 @@ linters:
   disable:
 # Disabling the following linters since are deprecated:
     - tenv
+# Disabling the following linters since linting commeting is required:
     - nolintlint
-    - gofumpt
-    - iface
-    - gci
-    - depguard
 # Disabling the following linters since are not mostly adopted, eg:
 # https://google.github.io/styleguide/go/decisions#external-context-vs-local-names
     - exhaustruct
     - varnamelen
     - tagliatelle
     - nilnil
+    - gofumpt
+    - iface
+    - gci
+    - depguard
   wsl:
     force-err-cuddling: true
     force-short-decl-cuddling: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - gofumpt
     - iface
     - gci
+    - depguard
 # Disabling the following linters since are not mostly adopted, eg:
 # https://google.github.io/styleguide/go/decisions#external-context-vs-local-names
     - exhaustruct

--- a/puller/puller.go
+++ b/puller/puller.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-git/go-git/v5"
 	"graphql-go/compatibility-standard-definitions/types"
+
+	"github.com/go-git/go-git/v5"
 )
 
 // reposDirName is the code repository root directory name.


### PR DESCRIPTION
#### Details
- `.golangci.yml`: disabling depguard.
- `puller`: fixes for golangci-lint goimports linter.
- `.golangci.yml`: consolidates linters disabling section.

#### Test Plan

:heavy_check_mark:  Tested that the `./bin/lint.sh` works as expected:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-standard-definitions$ ./bin/lint.sh 
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-standard-definitions$ 
```
