### PR TITLE
{extractor,app}: improvements related to wiring configuration.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 
+	"graphql-go/compatibility-standard-definitions/config"
 	"graphql-go/compatibility-standard-definitions/executor"
 	"graphql-go/compatibility-standard-definitions/extractor"
 	"graphql-go/compatibility-standard-definitions/puller"
@@ -12,6 +13,8 @@ import (
 
 // App represents the high level entry point for the application.
 type App struct {
+	// Config is the configuration of the application.
+	Config *config.Config
 }
 
 // RunResult represents the result of the run method.
@@ -42,7 +45,10 @@ func (app *App) Run(params RunParams) (*RunResult, error) {
 
 	executor := executor.New()
 
-	ex := extractor.New(executor)
+	ex := extractor.New(&extractor.NewParams{
+		Config:   app.Config,
+		Executor: executor,
+	})
 
 	extractResult, err := ex.Extract(&extractor.ExtractParams{
 		Implementation: params.Implementation,

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -25,7 +25,7 @@ type Extractor struct {
 	// executor is the executor component that extractor delegates the execution of a graphql introspection query.
 	executor *executor.Executor
 
-	// cfg is the configuration struct.
+	// cfg is the configuration of the application.
 	cfg *config.Config
 }
 

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -38,7 +38,7 @@ type NewParams struct {
 	Config *config.Config
 }
 
-// New returns a pointer to a Extractor struct.
+// New returns a pointer to an Extractor struct.
 func New(params *NewParams) *Extractor {
 	return &Extractor{
 		executor: params.Executor,

--- a/extractor/extractor.go
+++ b/extractor/extractor.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"graphql-go/compatibility-standard-definitions/config"
 	"graphql-go/compatibility-standard-definitions/executor"
 	"graphql-go/compatibility-standard-definitions/types"
 )
@@ -23,12 +24,25 @@ const introspectionQueryFilePath string = "./graphql-js-introspection/query.grap
 type Extractor struct {
 	// executor is the executor component that extractor delegates the execution of a graphql introspection query.
 	executor *executor.Executor
+
+	// cfg is the configuration struct.
+	cfg *config.Config
+}
+
+// NewParams represents the paramters for the new method.
+type NewParams struct {
+	// Executor is the executor parameter.
+	Executor *executor.Executor
+
+	// Config is the configuration parameter.
+	Config *config.Config
 }
 
 // New returns a pointer to a Extractor struct.
-func New(executor *executor.Executor) *Extractor {
+func New(params *NewParams) *Extractor {
 	return &Extractor{
-		executor: executor,
+		executor: params.Executor,
+		cfg:      params.Config,
 	}
 }
 
@@ -137,7 +151,9 @@ func (e *Extractor) parseSpec() (types.SpecificationIntrospection, error) {
 		}
 	}
 
-	log.Println(headingsLevel2)
+	if e.cfg.IsDebug {
+		log.Println(headingsLevel2)
+	}
 
 	spec := types.SpecificationIntrospection{
 		QueryResult: types.IntrospectionQueryResult{},

--- a/main.go
+++ b/main.go
@@ -19,7 +19,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	app := mainApp.App{}
+	app := mainApp.App{
+		Config: cfg,
+	}
 
 	runResult, err := app.Run(mainApp.RunParams{
 		Specification:  cfg.GraphqlSpecification,


### PR DESCRIPTION
#### Details
- `extractor`: wires config to extractor.
- `app`: wires config to app.

#### Test Plan

:heavy_check_mark:  Tested that the cli app works as expected:

```
$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
2025/03/26 16:43:08 failed to extract: failed extract implementation: failed to execute: Cannot query field "deprecationReason" on type "__InputValue".: Cannot query field "isDeprecated" on type "__InputValue".: Unknown argument "includeDeprecated" on field "inputFields" of type "__Type".: Unknown argument "includeDeprecated" on field "args" of type "__Field".: Cannot query field "isOneOf" on type "__Type".: Cannot query field "specifiedByURL" on type "__Type".: Unknown argument "includeDeprecated" on field "args" of type "__Directive".: Cannot query field "isRepeatable" on type "__Directive".: Cannot query field "description" on type "__Schema". Did you mean "subscriptionType"?
exit status 1
```
