### PR TITLE
`{Introspection}`: Adds scaffolding pkg.

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go clean -testcache && go test ./...

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/google/go-cmp v0.7.0
 	github.com/graphql-go/graphql v0.8.1
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
@@ -21,6 +22,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -36,6 +38,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
@@ -46,4 +49,5 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -1,0 +1,23 @@
+// Package introspection provides different types for interacting with GraphQL introspection operations.
+package introspection
+
+import "graphql-go/compatibility-standard-definitions/types"
+
+// queryResultFilePath is the file path of the introspection result against the graphql javascript implementation.
+const queryResultFilePath string = "./graphql-js-introspection/introspectionQueryResult.json"
+
+// Introspection represents a wrapper for operations related to GraphQL introspection.
+type Introspection struct {
+}
+
+// NewIntrospection returns a pointer to the Introspection struct.
+func NewIntrospection() *Introspection {
+	return &Introspection{}
+}
+
+// SpecificationQuery maps `queryResultFilePath` to `types.IntrospectionQueryResult`.
+func (i *Introspection) SpecificationQuery() (*types.IntrospectionQueryResult, error) {
+	result := &types.IntrospectionQueryResult{}
+	// TODO(@mentatbot): Map the `queryResultFilePath` json contents to `result` matching the exact fields.
+	return result, nil
+}

--- a/introspection/introspection_test.go
+++ b/introspection/introspection_test.go
@@ -1,0 +1,22 @@
+package introspection
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"graphql-go/compatibility-standard-definitions/types"
+)
+
+func TestSpecificationQuery(t *testing.T) {
+	introspection := NewIntrospection()
+
+	result, err := introspection.SpecificationQuery()
+	if err != nil {
+		log.Fatalf("expected no error, got: %v", err)
+	}
+
+	expected := &types.IntrospectionQueryResult{}
+
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
#### Details
- Closes: https://github.com/graphql-go/compatibility-standard-definitions/issues/45.
- `introspection`: adds scaffolding parts.
- `bin`: adds test.sh script.
- `go.mod`: adds github.com/stretchr/testify pkg.

#### Test Plan

:heavy_check_mark: Tested that `./bin/test.sh` works as expected:

```
?   	graphql-go/compatibility-standard-definitions	[no test files]
?   	graphql-go/compatibility-standard-definitions/app	[no test files]
?   	graphql-go/compatibility-standard-definitions/bubbletea	[no test files]
?   	graphql-go/compatibility-standard-definitions/cmd	[no test files]
?   	graphql-go/compatibility-standard-definitions/config	[no test files]
?   	graphql-go/compatibility-standard-definitions/executor	[no test files]
?   	graphql-go/compatibility-standard-definitions/extractor	[no test files]
?   	graphql-go/compatibility-standard-definitions/implementation	[no test files]
ok  	graphql-go/compatibility-standard-definitions/introspection	0.002s
?   	graphql-go/compatibility-standard-definitions/puller	[no test files]
?   	graphql-go/compatibility-standard-definitions/types	[no test files]
?   	graphql-go/compatibility-standard-definitions/validator	[no test files]
```

:heavy_check_mark: Tested that `CLI` works as expected:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-standard-definitions$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
```

```
2025/06/10 07:56:34 FAILURE
2025/06/10 07:56:34   types.IntrospectionQueryResult{
  	Schema: types.IntrospectionSchema{
  		Description: "",
...
  		},
  		Directives: {{Name: "include", Description: "Directs the executor to include this field or fragment only when"..., Locations: {"FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"}, Args: {{Name: "if", Description: "Included when true."}}}, {Name: "skip", Description: "Directs the executor to skip this field or fragment when the `if"..., Locations: {"FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"}, Args: {{Name: "if", Description: "Skipped when true."}}}, {Name: "deprecated", Description: "Marks an element of a GraphQL schema as no longer supported.", Locations: {"FIELD_DEFINITION", "ENUM_VALUE"}, Args: {{Name: "reason", Description: "Explains why this element was deprecated, usually also including"..., DefaultValue: `"No longer supported"`}}}},
  	},
  }

```
