### PR TITLE
`{executor/go}`: Update the root query name to match the one from graphql-js introspection query result.

### DIFF
--- a/executor/go.go
+++ b/executor/go.go
@@ -23,7 +23,7 @@ func NewGo() *Go {
 	g := &Go{}
 
 	g.rootQuery = graphql.ObjectConfig{
-		Name: "RootQuery",
+		Name: "RootQueryType",
 		Fields: graphql.Fields{
 			"echo": &graphql.Field{
 				Type: graphql.String,


### PR DESCRIPTION
#### Details
- Closes: https://github.com/graphql-go/compatibility-standard-definitions/issues/55
- `executor`: updates the root query name to match the graphql-js query result.

#### Test Plan

:heavy_check_mark:  Tested that `./bin/test.sh` works as expected:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-standard-definitions$ ./bin/test.sh
?   	graphql-go/compatibility-standard-definitions	[no test files]
?   	graphql-go/compatibility-standard-definitions/app	[no test files]
?   	graphql-go/compatibility-standard-definitions/bubbletea	[no test files]
?   	graphql-go/compatibility-standard-definitions/cmd	[no test files]
?   	graphql-go/compatibility-standard-definitions/config	[no test files]
?   	graphql-go/compatibility-standard-definitions/executor	[no test files]
?   	graphql-go/compatibility-standard-definitions/extractor	[no test files]
?   	graphql-go/compatibility-standard-definitions/implementation	[no test files]
ok  	graphql-go/compatibility-standard-definitions/introspection	0.003s
?   	graphql-go/compatibility-standard-definitions/puller	[no test files]
?   	graphql-go/compatibility-standard-definitions/types	[no test files]
?   	graphql-go/compatibility-standard-definitions/validator	[no test files]

```

:heavy_check_mark:  Tested that `./bin/start.sh` works as expected:

```
(base) chris@chris:~/Projects/graphql-compatibility/compatibility-standard-definitions$ ./bin/start.sh 
Specification: https://github.com/graphql/graphql-spec/releases/tag/October2021
(•) Implementation: https://github.com/graphql-go/graphql/releases/tag/v0.8.1


(press q to quit)
...
2025/06/11 15:44:27 FAILURE
2025/06/11 15:44:27   types.IntrospectionQueryResult{
  	Schema: types.IntrospectionSchema{
  		... // 2 identical fields
  		MutationType:     nil,
  		SubscriptionType: nil,
  		Types: []types.IntrospectionFullType{
- 			{
...
  		Directives: {{Name: "include", Description: &"Directs the executor to include this field or fragment only when"..., Locations: {"FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"}, Args: {{Name: "if", Description: &"Included when true.", Type: {Kind: "NON_NULL", OfType: &{Kind: "SCALAR", Name: &"Boolean"}}}}}, {Name: "skip", Description: &"Directs the executor to skip this field or fragment when the `if"..., Locations: {"FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"}, Args: {{Name: "if", Description: &"Skipped when true.", Type: {Kind: "NON_NULL", OfType: &{Kind: "SCALAR", Name: &"Boolean"}}}}}, {Name: "deprecated", Description: &"Marks an element of a GraphQL schema as no longer supported.", Locations: {"FIELD_DEFINITION", "ENUM_VALUE"}, Args: {{Name: "reason", Description: &"Explains why this element was deprecated, usually also including"..., Type: {Kind: "SCALAR", Name: &"String"}, DefaultValue: &`"No longer supported"`}}}},
  	},
  }
```
